### PR TITLE
Travis docker cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ services:
 cache:
   directories:
     - $HOME/.cache/pip
-    - /var/lib/docker
+    - /var/lib/docker/image
+    - /var/lib/docker/containers
+    - /var/lib/docker/aufs
 
 env:
   SSL_KEY: nginx.key

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: python
 
 python:
@@ -7,6 +5,11 @@ python:
 
 services:
   - docker
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - /var/lib/docker
 
 env:
   SSL_KEY: nginx.key
@@ -17,7 +20,7 @@ env:
   DOCKER_REGISTRY_PASSWORD:
 
 before_install:
-  - sudo pip install docker-compose==1.9.0
+  - pip install docker-compose==1.9.0
   - openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj "/C=US/ST=Test/L=Test/O=Dis/CN=localhost" -keyout "etc/ssl/${SSL_KEY}" -out "etc/ssl/${SSL_CERT}"
 
 install:


### PR DESCRIPTION
В travis есть экспериментальная фича по кешу директорий между контейнерами.
Это поможет нам сохранять кеш докера и билды должны быть быстрее.