### PR TITLE
money-bot: fix case-insensitivity

### DIFF
--- a/money-bot/app.js
+++ b/money-bot/app.js
@@ -42,7 +42,7 @@ let currency = {
 
 
 app.post('/event', function(req, res) {
-    let text = req.body.text;
+    let text = req.body.text.toLowerCase();
     waterfall([
         function(callback){
             let v = 0;

--- a/money-bot/bot-spec.yml
+++ b/money-bot/bot-spec.yml
@@ -26,3 +26,5 @@ test_cases:
     result: "\\*\\*_user_\\*\\* упомянул 5 000 000\\.51 USD.*"
   - command: "₽42к"
     result: "\\*\\*_user_\\*\\* упомянул 42 000 RUB.*"
+  - command: "5К $"
+    result: "\\*\\*_user_\\*\\* упомянул 5 000 USD.+"


### PR DESCRIPTION
Пофиксил обработку ключевых слов с кириллическими символами в верхнем регистре.  
Оказывается в JS case-insensitive флаг в regexps работает только с латинскими символами.
